### PR TITLE
feat: separate corrected labels directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Interactive tool for reviewing YOLO annotations. It runs an Ultralytics YOLO mod
 ## Usage
 
 ```
-python annotation_corrector.py --images path/to/images --labels path/to/labels --model path/to/weights.pt
+python annotation_corrector.py --images path/to/images --labels path/to/original_labels --corrected path/to/corrected_labels --model path/to/weights.pt
 ```
+
+The script copies all label files from the `--labels` directory into the `--corrected` directory. Any accepted or edited labels are written to the corrected directory, leaving the originals untouched.
 
 Model predictions are drawn in **red** and existing labels in **green**. For each disagreement you can:
 

--- a/annotation_corrector.py
+++ b/annotation_corrector.py
@@ -1,6 +1,7 @@
 import argparse
 import glob
 import os
+import shutil
 from typing import List
 
 import matplotlib.pyplot as plt
@@ -85,9 +86,16 @@ def show_interface(image: Image.Image, pred_lines: List[str], label_lines: List[
 def main():
     parser = argparse.ArgumentParser(description="YOLO Annotation Corrector")
     parser.add_argument("--images", required=True, help="Path to images directory")
-    parser.add_argument("--labels", required=True, help="Path to labels directory")
+    parser.add_argument("--labels", required=True, help="Path to original labels directory")
+    parser.add_argument("--corrected", required=True, help="Directory to write corrected labels")
     parser.add_argument("--model", required=True, help="Path to YOLO model weights")
     args = parser.parse_args()
+
+    os.makedirs(args.corrected, exist_ok=True)
+    for src in glob.glob(os.path.join(args.labels, '*.txt')):
+        dst = os.path.join(args.corrected, os.path.basename(src))
+        if not os.path.exists(dst):
+            shutil.copy(src, dst)
 
     model = YOLO(args.model)
     image_paths = sorted(glob.glob(os.path.join(args.images, '*')))
@@ -100,7 +108,7 @@ def main():
 
         pred_lines = format_predictions(boxes)
         base = os.path.splitext(os.path.basename(img_path))[0]
-        label_file = os.path.join(args.labels, base + '.txt')
+        label_file = os.path.join(args.corrected, base + '.txt')
         label_lines = load_labels(label_file)
 
         if set(pred_lines) == set(label_lines):


### PR DESCRIPTION
## Summary
- allow specifying an output directory for corrected labels
- copy existing labels to the corrected directory before review
- document new `--corrected` option in README

## Testing
- `python -m py_compile annotation_corrector.py`
- `python annotation_corrector.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6898cf7e0cd08326820b80cdee150448