### PR TITLE
Add PyQt6 GUI for annotation review

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 
 Interactive tool for reviewing YOLO annotations. It runs an Ultralytics YOLO model on a set of images and compares the predictions with existing label files. Only images where the predictions and labels differ are presented to the user for review.
 
+The application now provides a PyQt6 interface. Model predictions (in red) can be toggled on and off, each showing its confidence and a check mark for accepting the prediction. Existing labels (in green) display a cross that can be clicked to remove them. A preview window shows the final label lines before saving.
+
 ## Usage
 
 ```
 python annotation_corrector.py --images path/to/images --labels path/to/original_labels --corrected path/to/corrected_labels --model path/to/weights.pt
 ```
 
-The script copies all label files from the `--labels` directory into the `--corrected` directory. Any accepted or edited labels are written to the corrected directory, leaving the originals untouched.
+The script copies all label files from the `--labels` directory into the `--corrected` directory. Any accepted or edited labels are written to the corrected directory, leaving the originals untouched. Within the GUI you may:
 
-Model predictions are drawn in **red** and existing labels in **green**. For each disagreement you can:
-
-* **Accept** – overwrite labels with model predictions.
-* **Reject** – keep existing labels.
-* **Change** – enter new label lines in YOLO format.
+* Toggle prediction boxes on or off.
+* Click the **✓** on a prediction to include it.
+* Click the **✗** on a ground-truth box to remove it.
+* Use **Preview** to view the final labels before saving.
 
 Image preprocessing is defined in `preprocessing.py` and currently returns images unchanged.

--- a/annotation_corrector.py
+++ b/annotation_corrector.py
@@ -2,15 +2,14 @@ import argparse
 import glob
 import os
 import shutil
-from typing import List
+from typing import List, Tuple
 
-import matplotlib.pyplot as plt
-import matplotlib.patches as patches
 import numpy as np
 from PIL import Image
 from ultralytics import YOLO
 
 from preprocessing import preprocess
+from qt_interface import run_interface
 
 
 def load_labels(label_file: str) -> List[str]:
@@ -28,59 +27,15 @@ def load_labels(label_file: str) -> List[str]:
         return [line.strip() for line in f if line.strip()]
 
 
-def format_predictions(boxes) -> List[str]:
-    """Format model predictions as YOLO label strings."""
-    lines = []
+def format_predictions(boxes) -> List[Tuple[str, float]]:
+    """Format model predictions as YOLO label strings with confidences."""
+    lines: List[Tuple[str, float]] = []
     for b in boxes:
         cls = int(b.cls.item())
         xc, yc, w, h = b.xywhn.tolist()[0]
-        lines.append(f"{cls} {xc:.6f} {yc:.6f} {w:.6f} {h:.6f}")
+        conf = float(b.conf.item())
+        lines.append((f"{cls} {xc:.6f} {yc:.6f} {w:.6f} {h:.6f}", conf))
     return lines
-
-
-def draw_boxes(ax, lines: List[str], img_w: int, img_h: int, color: str):
-    """Draw YOLO-format boxes on a matplotlib axis."""
-    for line in lines:
-        parts = line.split()
-        if len(parts) != 5:
-            continue
-        cls, xc, yc, w, h = parts
-        xc, yc, w, h = map(float, (xc, yc, w, h))
-        x1 = (xc - w / 2) * img_w
-        y1 = (yc - h / 2) * img_h
-        rect = patches.Rectangle((x1, y1), w * img_w, h * img_h,
-                                 linewidth=2, edgecolor=color, facecolor='none')
-        ax.add_patch(rect)
-        ax.text(x1, y1, cls, color=color)
-
-
-def show_interface(image: Image.Image, pred_lines: List[str], label_lines: List[str], label_file: str):
-    """Display image with predictions and labels and handle user input."""
-    img_w, img_h = image.size
-    fig, ax = plt.subplots(1)
-    ax.imshow(image)
-
-    draw_boxes(ax, pred_lines, img_w, img_h, 'r')
-    draw_boxes(ax, label_lines, img_w, img_h, 'g')
-    plt.title("Red: predictions, Green: labels")
-    plt.show(block=False)
-
-    action = input("Accept predictions (a), Reject (r), Change (c)? ").strip().lower()
-    plt.close(fig)
-
-    if action == 'a':
-        os.makedirs(os.path.dirname(label_file), exist_ok=True)
-        with open(label_file, 'w') as f:
-            for line in pred_lines:
-                f.write(line + '\n')
-    elif action == 'c':
-        new_lines = input("Enter new labels in YOLO format separated by semicolons: ").strip()
-        lines = [l.strip() for l in new_lines.split(';') if l.strip()]
-        os.makedirs(os.path.dirname(label_file), exist_ok=True)
-        with open(label_file, 'w') as f:
-            for line in lines:
-                f.write(line + '\n')
-    # else: reject - keep existing labels
 
 
 def main():
@@ -111,10 +66,10 @@ def main():
         label_file = os.path.join(args.corrected, base + '.txt')
         label_lines = load_labels(label_file)
 
-        if set(pred_lines) == set(label_lines):
+        if set(line for line, _ in pred_lines) == set(label_lines):
             continue
 
-        show_interface(processed, pred_lines, label_lines, label_file)
+        run_interface(processed, pred_lines, label_lines, label_file)
 
 
 if __name__ == "__main__":

--- a/qt_interface.py
+++ b/qt_interface.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import os
+from typing import List, Tuple
+
+from PyQt6.QtCore import Qt, QRectF
+from PyQt6.QtGui import QColor, QImage, QPen, QPixmap
+from PyQt6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QGraphicsPixmapItem,
+    QGraphicsRectItem,
+    QGraphicsScene,
+    QGraphicsTextItem,
+    QGraphicsView,
+    QHBoxLayout,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+def yolo_line_to_rect(line: str, img_w: int, img_h: int) -> QRectF:
+    """Convert a YOLO label line to a QRectF."""
+    parts = line.split()
+    if len(parts) != 5:
+        return QRectF()
+    _, xc, yc, w, h = parts
+    xc, yc, w, h = map(float, (xc, yc, w, h))
+    x1 = (xc - w / 2) * img_w
+    y1 = (yc - h / 2) * img_h
+    return QRectF(x1, y1, w * img_w, h * img_h)
+
+
+class PredBox(QGraphicsRectItem):
+    """Graphics item for a predicted box."""
+
+    def __init__(self, rect: QRectF, line: str, conf: float):
+        super().__init__(rect)
+        self.line = line
+        self.conf = conf
+        self.accepted = False
+        self.setPen(QPen(QColor("red"), 2))
+
+        cls = line.split()[0]
+        self.label = QGraphicsTextItem(f"{cls}:{conf:.2f}", self)
+        self.label.setDefaultTextColor(QColor("red"))
+        self.label.setPos(rect.left(), rect.top() - 15)
+
+        self.tick = QGraphicsTextItem("✓", self)
+        self.tick.setDefaultTextColor(QColor("gray"))
+        self.tick.setPos(rect.left(), rect.top())
+
+    def mousePressEvent(self, event):
+        self.accepted = not self.accepted
+        color = QColor("green") if self.accepted else QColor("gray")
+        self.tick.setDefaultTextColor(color)
+        super().mousePressEvent(event)
+
+
+class GTBox(QGraphicsRectItem):
+    """Graphics item for an existing ground truth box."""
+
+    def __init__(self, rect: QRectF, line: str):
+        super().__init__(rect)
+        self.line = line
+        self.kept = True
+        self.setPen(QPen(QColor("green"), 2))
+
+        self.cross = QGraphicsTextItem("✗", self)
+        self.cross.setDefaultTextColor(QColor("red"))
+        self.cross.setPos(rect.left(), rect.top())
+
+    def mousePressEvent(self, event):
+        self.kept = not self.kept
+        color = QColor("red") if self.kept else QColor("gray")
+        self.cross.setDefaultTextColor(color)
+        super().mousePressEvent(event)
+
+
+class AnnotationWindow(QMainWindow):
+    """Main window providing annotation controls."""
+
+    def __init__(
+        self,
+        pixmap: QPixmap,
+        predictions: List[Tuple[str, float]],
+        labels: List[str],
+        label_file: str,
+    ):
+        super().__init__()
+        self.setWindowTitle("YOLO Annotation Corrector")
+        self.label_file = label_file
+
+        self.scene = QGraphicsScene(self)
+        self.view = QGraphicsView(self.scene)
+        self.scene.addItem(QGraphicsPixmapItem(pixmap))
+
+        img_w = pixmap.width()
+        img_h = pixmap.height()
+
+        self.pred_items: List[PredBox] = []
+        for line, conf in predictions:
+            rect = yolo_line_to_rect(line, img_w, img_h)
+            item = PredBox(rect, line, conf)
+            self.scene.addItem(item)
+            self.pred_items.append(item)
+
+        self.gt_items: List[GTBox] = []
+        for line in labels:
+            rect = yolo_line_to_rect(line, img_w, img_h)
+            item = GTBox(rect, line)
+            self.scene.addItem(item)
+            self.gt_items.append(item)
+
+        self.pred_checkbox = QCheckBox("Show predictions")
+        self.pred_checkbox.setChecked(True)
+        self.pred_checkbox.toggled.connect(self.toggle_predictions)
+
+        self.preview_btn = QPushButton("Preview")
+        self.preview_btn.clicked.connect(self.preview)
+
+        self.save_btn = QPushButton("Save")
+        self.save_btn.clicked.connect(self.save_and_close)
+
+        control_layout = QHBoxLayout()
+        control_layout.addWidget(self.pred_checkbox)
+        control_layout.addWidget(self.preview_btn)
+        control_layout.addWidget(self.save_btn)
+        controls = QWidget()
+        controls.setLayout(control_layout)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.view)
+        layout.addWidget(controls)
+
+        container = QWidget()
+        container.setLayout(layout)
+        self.setCentralWidget(container)
+
+    def toggle_predictions(self, state: bool):
+        for item in self.pred_items:
+            item.setVisible(state)
+
+    def preview(self):
+        lines = [i.line for i in self.gt_items if i.kept]
+        lines += [i.line for i in self.pred_items if i.accepted]
+        text = "\n".join(lines) if lines else "No labels selected"
+        QMessageBox.information(self, "Final Labels", text)
+
+    def save_and_close(self):
+        lines = [i.line for i in self.gt_items if i.kept]
+        lines += [i.line for i in self.pred_items if i.accepted]
+        os.makedirs(os.path.dirname(self.label_file), exist_ok=True)
+        with open(self.label_file, "w") as f:
+            for line in lines:
+                f.write(line + "\n")
+        self.close()
+
+
+def run_interface(image, predictions: List[Tuple[str, float]], label_lines: List[str], label_file: str):
+    """Launch the PyQt6 interface for a single image."""
+    img = image.convert("RGB")
+    data = img.tobytes("raw", "RGB")
+    qimg = QImage(data, img.width, img.height, QImage.Format.Format_RGB888)
+    pixmap = QPixmap.fromImage(qimg)
+
+    app = QApplication.instance() or QApplication([])
+    window = AnnotationWindow(pixmap, predictions, label_lines, label_file)
+    window.show()
+    app.exec()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ultralytics
-matplotlib
 pillow
+PyQt6


### PR DESCRIPTION
## Summary
- Replace matplotlib CLI with PyQt6 interface for reviewing annotations
- Display prediction confidence, add tick/cross controls, and preview final labels
- Update requirements and documentation for new GUI workflow

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898d89fb7188326911c5882468d109c