### PR TITLE
Use SAHI sliding window inference for annotation correction

### DIFF
--- a/annotation_corrector.py
+++ b/annotation_corrector.py
@@ -2,12 +2,11 @@ import argparse
 import glob
 import os
 import shutil
-from typing import List, Tuple
+from typing import List
 
-import numpy as np
 from PIL import Image
-from ultralytics import YOLO
 
+from inference import load_model, predict
 from preprocessing import preprocess
 from qt_interface import run_interface
 
@@ -27,17 +26,6 @@ def load_labels(label_file: str) -> List[str]:
         return [line.strip() for line in f if line.strip()]
 
 
-def format_predictions(boxes) -> List[Tuple[str, float]]:
-    """Format model predictions as YOLO label strings with confidences."""
-    lines: List[Tuple[str, float]] = []
-    for b in boxes:
-        cls = int(b.cls.item())
-        xc, yc, w, h = b.xywhn.tolist()[0]
-        conf = float(b.conf.item())
-        lines.append((f"{cls} {xc:.6f} {yc:.6f} {w:.6f} {h:.6f}", conf))
-    return lines
-
-
 def main():
     parser = argparse.ArgumentParser(description="YOLO Annotation Corrector")
     parser.add_argument("--images", required=True, help="Path to images directory")
@@ -52,16 +40,13 @@ def main():
         if not os.path.exists(dst):
             shutil.copy(src, dst)
 
-    model = YOLO(args.model)
+    model = load_model(args.model)
     image_paths = sorted(glob.glob(os.path.join(args.images, '*')))
 
     for img_path in image_paths:
         image = Image.open(img_path).convert('RGB')
         processed = preprocess(image)
-        results = model(np.array(processed))
-        boxes = results[0].boxes
-
-        pred_lines = format_predictions(boxes)
+        pred_lines = predict(model, processed)
         base = os.path.splitext(os.path.basename(img_path))[0]
         label_file = os.path.join(args.corrected, base + '.txt')
         label_lines = load_labels(label_file)

--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,89 @@
+"""Inference utilities using SAHI for sliding window predictions.
+
+This module provides helper functions to load a YOLO model and run
+inference on large images by slicing them into 640x640 windows using
+`sahi` (Slicing Aided Hyper Inference). Predictions are returned in the
+same format as YOLO label files with an accompanying confidence score.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from PIL import Image
+from sahi import AutoDetectionModel
+from sahi.predict import get_sliced_prediction
+
+
+def load_model(model_path: str, device: str | None = None) -> AutoDetectionModel:
+    """Load a YOLO model for sliced inference.
+
+    Args:
+        model_path: Path to the YOLO weights file.
+        device: Device identifier (e.g., ``"cuda:0"`` or ``"cpu"``).
+            If ``None``, ``sahi`` will select the available device.
+
+    Returns:
+        AutoDetectionModel: Wrapped detection model ready for SAHI inference.
+    """
+
+    return AutoDetectionModel.from_pretrained(
+        model_type="yolov8",
+        model_path=model_path,
+        device=device,
+    )
+
+
+def predict(
+    model: AutoDetectionModel, image: Image.Image
+) -> List[Tuple[str, float]]:
+    """Run sliced prediction on an image and return YOLO-formatted boxes.
+
+    The image is processed with a 640x640 sliding window and a small overlap
+    to ensure objects at the borders are detected. Each prediction is
+    formatted as a tuple containing the YOLO label line and its confidence
+    score.
+
+    Args:
+        model: Loaded ``AutoDetectionModel`` from :func:`load_model`.
+        image: Input image on which inference will be performed.
+
+    Returns:
+        List[Tuple[str, float]]: List of ``("cls xc yc w h", confidence)``
+        pairs with normalized coordinates.
+    """
+
+    result = get_sliced_prediction(
+        image,
+        detection_model=model,
+        slice_height=640,
+        slice_width=640,
+        overlap_height_ratio=0.2,
+        overlap_width_ratio=0.2,
+    )
+
+    img_w, img_h = image.size
+    lines: List[Tuple[str, float]] = []
+    for obj in result.object_prediction_list:
+        bbox = obj.bbox
+        x1, y1, x2, y2 = bbox.minx, bbox.miny, bbox.maxx, bbox.maxy
+        w = x2 - x1
+        h = y2 - y1
+        xc = x1 + w / 2
+        yc = y1 + h / 2
+
+        # Normalize coordinates to image dimensions
+        norm = (
+            xc / img_w,
+            yc / img_h,
+            w / img_w,
+            h / img_h,
+        )
+
+        cls = obj.category.id
+        conf = obj.score.value
+        line = f"{cls} {norm[0]:.6f} {norm[1]:.6f} {norm[2]:.6f} {norm[3]:.6f}"
+        lines.append((line, conf))
+
+    return lines
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ultralytics
 pillow
 PyQt6
+sahi


### PR DESCRIPTION
## Summary
- add inference helpers built on SAHI
- perform 640x640 sliding-window predictions in `annotation_corrector`
- include SAHI in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile annotation_corrector.py inference.py preprocessing.py qt_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_6898db1e4c608326bc425fe6a563493d