### PR TITLE
Initialize QApplication before QPixmap creation

### DIFF
--- a/qt_interface.py
+++ b/qt_interface.py
@@ -162,12 +162,13 @@ class AnnotationWindow(QMainWindow):
 
 def run_interface(image, predictions: List[Tuple[str, float]], label_lines: List[str], label_file: str):
     """Launch the PyQt6 interface for a single image."""
+    app = QApplication.instance() or QApplication([])
+
     img = image.convert("RGB")
     data = img.tobytes("raw", "RGB")
     qimg = QImage(data, img.width, img.height, QImage.Format.Format_RGB888)
     pixmap = QPixmap.fromImage(qimg)
 
-    app = QApplication.instance() or QApplication([])
     window = AnnotationWindow(pixmap, predictions, label_lines, label_file)
     window.show()
     app.exec()


### PR DESCRIPTION
## Summary
- Ensure QApplication is instantiated before creating QPixmap in the interface.

## Testing
- `python -m py_compile qt_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_6898df2182348326893be73020d4f427