### PR TITLE
Add multi-image navigation and display controls to annotation UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Interactive tool for reviewing YOLO annotations. It runs an Ultralytics YOLO model on a set of images and compares the predictions with existing label files. Only images where the predictions and labels differ are presented to the user for review.
 
-The application now provides a PyQt6 interface. Model predictions (in red) can be toggled on and off, each showing its confidence and a check mark for accepting the prediction. Existing labels (in green) display a cross that can be clicked to remove them. A preview window shows the final label lines before saving.
+The application provides a single PyQt6 interface that lets you work through all images without reopening the window. Model predictions (in red) can be toggled on and off, each showing its confidence and a check mark for accepting the prediction. Existing labels (in green) display a cross that can be clicked to remove them. A preview window shows the final label lines before saving.
 
 ## Usage
 
@@ -15,6 +15,9 @@ The script copies all label files from the `--labels` directory into the `--corr
 * Toggle prediction boxes on or off.
 * Click the **✓** on a prediction to include it.
 * Click the **✗** on a ground-truth box to remove it.
-* Use **Preview** to view the final labels before saving.
+* Adjust image display using brightness and contrast sliders.
+* Move between images with **Previous** and **Next**.
+* Press **Save** to write labels for all images and **Exit** to close the tool.
+* Use **Preview** to view the final labels for the current image.
 
 Image preprocessing is defined in `preprocessing.py` and currently returns images unchanged.

--- a/annotation_corrector.py
+++ b/annotation_corrector.py
@@ -44,6 +44,11 @@ def main():
     class_names = getattr(getattr(model, "model", None), "names", [])
     image_paths = sorted(glob.glob(os.path.join(args.images, '*')))
 
+    images = []
+    predictions = []
+    labels = []
+    label_files = []
+
     for img_path in image_paths:
         image = Image.open(img_path).convert('RGB')
         processed = preprocess(image)
@@ -55,7 +60,13 @@ def main():
         if set(line for line, _ in pred_lines) == set(label_lines):
             continue
 
-        run_interface(processed, pred_lines, label_lines, label_file, class_names)
+        images.append(processed)
+        predictions.append([{"line": line, "conf": conf, "accepted": False} for line, conf in pred_lines])
+        labels.append([{"line": line, "kept": True} for line in label_lines])
+        label_files.append(label_file)
+
+    if images:
+        run_interface(images, predictions, labels, label_files, class_names)
 
 
 if __name__ == "__main__":

--- a/qt_interface.py
+++ b/qt_interface.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import os
-from typing import List, Tuple
+from typing import List
 
+from PIL import ImageEnhance
 from PyQt6.QtCore import Qt, QRectF
 from PyQt6.QtGui import QColor, QImage, QPen, QPixmap
 from PyQt6.QtWidgets import (
@@ -14,9 +15,11 @@ from PyQt6.QtWidgets import (
     QGraphicsTextItem,
     QGraphicsView,
     QHBoxLayout,
+    QLabel,
     QMainWindow,
     QMessageBox,
     QPushButton,
+    QSlider,
     QVBoxLayout,
     QWidget,
 )
@@ -50,18 +53,19 @@ def yolo_line_to_rect(line: str, img_w: int, img_h: int) -> QRectF:
 class PredBox(QGraphicsRectItem):
     """Graphics item for a predicted box."""
 
-    def __init__(self, rect: QRectF, line: str, conf: float, class_names: List[str], window: "AnnotationWindow"):
+    def __init__(self, rect: QRectF, state: dict, class_names: List[str], window: "AnnotationWindow"):
         super().__init__(rect)
         self.window = window
-        self.line = line
-        self.conf = conf
-        self.accepted = False
+        self.state = state
+        self.line = state["line"]
+        self.conf = state["conf"]
+        self.accepted = state.get("accepted", False)
         self.setPen(QPen(QColor("red"), 2))
 
-        cls_id = int(line.split()[0])
+        cls_id = int(self.line.split()[0])
         cls_name = class_names[cls_id] if 0 <= cls_id < len(class_names) else str(cls_id)
         self.label = QGraphicsTextItem(self)
-        self.label.setHtml(f"<div style='background-color:white;'>{cls_name}:{conf:.2f}</div>")
+        self.label.setHtml(f"<div style='background-color:white;'>{cls_name}:{self.conf:.2f}</div>")
         self.label.setPos(rect.left(), rect.top() - 20)
 
         self.tick = QGraphicsTextItem(self)
@@ -74,6 +78,7 @@ class PredBox(QGraphicsRectItem):
 
     def mousePressEvent(self, event):
         self.accepted = not self.accepted
+        self.state["accepted"] = self.accepted
         self._update_tick()
         super().mousePressEvent(event)
         if self.window.final_checkbox.isChecked():
@@ -83,14 +88,15 @@ class PredBox(QGraphicsRectItem):
 class GTBox(QGraphicsRectItem):
     """Graphics item for an existing ground truth box."""
 
-    def __init__(self, rect: QRectF, line: str, class_names: List[str], window: "AnnotationWindow"):
+    def __init__(self, rect: QRectF, state: dict, class_names: List[str], window: "AnnotationWindow"):
         super().__init__(rect)
         self.window = window
-        self.line = line
-        self.kept = True
+        self.state = state
+        self.line = state["line"]
+        self.kept = state.get("kept", True)
         self.setPen(QPen(QColor("green"), 2))
 
-        cls_id = int(line.split()[0])
+        cls_id = int(self.line.split()[0])
         cls_name = class_names[cls_id] if 0 <= cls_id < len(class_names) else str(cls_id)
         self.label = QGraphicsTextItem(self)
         self.label.setHtml(f"<div style='background-color:white;'>{cls_name}</div>")
@@ -106,6 +112,7 @@ class GTBox(QGraphicsRectItem):
 
     def mousePressEvent(self, event):
         self.kept = not self.kept
+        self.state["kept"] = self.kept
         self._update_cross()
         super().mousePressEvent(event)
         if self.window.final_checkbox.isChecked():
@@ -113,42 +120,30 @@ class GTBox(QGraphicsRectItem):
 
 
 class AnnotationWindow(QMainWindow):
-    """Main window providing annotation controls."""
+    """Main window providing annotation controls with multi-image navigation."""
 
     def __init__(
         self,
-        pixmap: QPixmap,
-        predictions: List[Tuple[str, float]],
-        labels: List[str],
-        label_file: str,
+        images: List,
+        predictions: List[List[dict]],
+        labels: List[List[dict]],
+        label_files: List[str],
         class_names: List[str],
     ):
         super().__init__()
         self.setWindowTitle("YOLO Annotation Corrector")
-        self.label_file = label_file
         self.class_names = class_names
+        self.images = images
+        self.pred_states = predictions
+        self.gt_states = labels
+        self.label_files = label_files
+        self.index = 0
 
         self.scene = QGraphicsScene(self)
         self.view = ZoomableGraphicsView(self.scene)
-        self.scene.addItem(QGraphicsPixmapItem(pixmap))
-
-        img_w = pixmap.width()
-        img_h = pixmap.height()
 
         self.pred_items: List[PredBox] = []
-        for line, conf in predictions:
-            rect = yolo_line_to_rect(line, img_w, img_h)
-            item = PredBox(rect, line, conf, class_names, self)
-            self.scene.addItem(item)
-            self.pred_items.append(item)
-
         self.gt_items: List[GTBox] = []
-        for line in labels:
-            rect = yolo_line_to_rect(line, img_w, img_h)
-            item = GTBox(rect, line, class_names, self)
-            self.scene.addItem(item)
-            self.gt_items.append(item)
-
         self.final_items: List[QGraphicsRectItem] = []
 
         self.pred_checkbox = QCheckBox("Show predictions")
@@ -167,7 +162,26 @@ class AnnotationWindow(QMainWindow):
         self.preview_btn.clicked.connect(self.preview)
 
         self.save_btn = QPushButton("Save")
-        self.save_btn.clicked.connect(self.save_and_close)
+        self.save_btn.clicked.connect(self.save_all)
+
+        self.prev_btn = QPushButton("Previous")
+        self.prev_btn.clicked.connect(self.prev_image)
+
+        self.next_btn = QPushButton("Next")
+        self.next_btn.clicked.connect(self.next_image)
+
+        self.exit_btn = QPushButton("Exit")
+        self.exit_btn.clicked.connect(self.close)
+
+        self.brightness_slider = QSlider(Qt.Orientation.Horizontal)
+        self.brightness_slider.setRange(0, 200)
+        self.brightness_slider.setValue(100)
+        self.brightness_slider.valueChanged.connect(self.update_image_display)
+
+        self.contrast_slider = QSlider(Qt.Orientation.Horizontal)
+        self.contrast_slider.setRange(0, 200)
+        self.contrast_slider.setValue(100)
+        self.contrast_slider.valueChanged.connect(self.update_image_display)
 
         control_layout = QHBoxLayout()
         control_layout.addWidget(self.pred_checkbox)
@@ -175,17 +189,111 @@ class AnnotationWindow(QMainWindow):
         control_layout.addWidget(self.final_checkbox)
         control_layout.addWidget(self.preview_btn)
         control_layout.addWidget(self.save_btn)
+        control_layout.addWidget(self.prev_btn)
+        control_layout.addWidget(self.next_btn)
+        control_layout.addWidget(self.exit_btn)
         controls = QWidget()
         controls.setLayout(control_layout)
 
+        slider_layout = QHBoxLayout()
+        slider_layout.addWidget(QLabel("Brightness"))
+        slider_layout.addWidget(self.brightness_slider)
+        slider_layout.addWidget(QLabel("Contrast"))
+        slider_layout.addWidget(self.contrast_slider)
+
         layout = QVBoxLayout()
         layout.addWidget(self.view)
+        layout.addLayout(slider_layout)
         layout.addWidget(controls)
 
         container = QWidget()
         container.setLayout(layout)
         self.setCentralWidget(container)
 
+        self.load_image(0)
+
+    # ------------------------------------------------------------------
+    # Image and box management
+    # ------------------------------------------------------------------
+    def pil_to_pixmap(self, img):
+        img = img.convert("RGB")
+        data = img.tobytes("raw", "RGB")
+        qimg = QImage(data, img.width, img.height, QImage.Format.Format_RGB888)
+        return QPixmap.fromImage(qimg)
+
+    def adjust_image(self, img):
+        b = self.brightness_slider.value() / 100.0
+        c = self.contrast_slider.value() / 100.0
+        out = img
+        if b != 1.0:
+            out = ImageEnhance.Brightness(out).enhance(b)
+        if c != 1.0:
+            out = ImageEnhance.Contrast(out).enhance(c)
+        return out
+
+    def load_image(self, index: int):
+        self.scene.clear()
+        self.pred_items = []
+        self.gt_items = []
+        self.final_items = []
+        self.index = index
+
+        img = self.images[index]
+        pixmap = self.pil_to_pixmap(self.adjust_image(img))
+        self.background_item = QGraphicsPixmapItem(pixmap)
+        self.scene.addItem(self.background_item)
+
+        img_w = pixmap.width()
+        img_h = pixmap.height()
+
+        for state in self.pred_states[index]:
+            rect = yolo_line_to_rect(state["line"], img_w, img_h)
+            item = PredBox(rect, state, self.class_names, self)
+            item.setVisible(self.pred_checkbox.isChecked())
+            self.scene.addItem(item)
+            self.pred_items.append(item)
+
+        for state in self.gt_states[index]:
+            rect = yolo_line_to_rect(state["line"], img_w, img_h)
+            item = GTBox(rect, state, self.class_names, self)
+            item.setVisible(self.gt_checkbox.isChecked())
+            self.scene.addItem(item)
+            self.gt_items.append(item)
+
+        self.update_final_items()
+
+    def update_image_display(self):
+        img = self.images[self.index]
+        pixmap = self.pil_to_pixmap(self.adjust_image(img))
+        self.background_item.setPixmap(pixmap)
+
+    # ------------------------------------------------------------------
+    # Navigation and saving
+    # ------------------------------------------------------------------
+    def next_image(self):
+        if self.index < len(self.images) - 1:
+            self.load_image(self.index + 1)
+
+    def prev_image(self):
+        if self.index > 0:
+            self.load_image(self.index - 1)
+
+    def collect_lines(self, idx: int) -> List[str]:
+        lines = [s["line"] for s in self.gt_states[idx] if s.get("kept", True)]
+        lines += [s["line"] for s in self.pred_states[idx] if s.get("accepted", False)]
+        return lines
+
+    def save_all(self):
+        for idx, label_file in enumerate(self.label_files):
+            lines = self.collect_lines(idx)
+            os.makedirs(os.path.dirname(label_file), exist_ok=True)
+            with open(label_file, "w") as f:
+                for line in lines:
+                    f.write(line + "\n")
+
+    # ------------------------------------------------------------------
+    # Visibility toggles and preview
+    # ------------------------------------------------------------------
     def toggle_predictions(self, state: bool):
         for item in self.pred_items:
             item.setVisible(state)
@@ -217,36 +325,21 @@ class AnnotationWindow(QMainWindow):
                 self.final_items.append(rect)
 
     def preview(self):
-        lines = [i.line for i in self.gt_items if i.kept]
-        lines += [i.line for i in self.pred_items if i.accepted]
+        lines = self.collect_lines(self.index)
         text = "\n".join(lines) if lines else "No labels selected"
         QMessageBox.information(self, "Final Labels", text)
 
-    def save_and_close(self):
-        lines = [i.line for i in self.gt_items if i.kept]
-        lines += [i.line for i in self.pred_items if i.accepted]
-        os.makedirs(os.path.dirname(self.label_file), exist_ok=True)
-        with open(self.label_file, "w") as f:
-            for line in lines:
-                f.write(line + "\n")
-        self.close()
-
 
 def run_interface(
-    image,
-    predictions: List[Tuple[str, float]],
-    label_lines: List[str],
-    label_file: str,
+    images: List,
+    predictions: List[List[dict]],
+    labels: List[List[dict]],
+    label_files: List[str],
     class_names: List[str],
 ):
-    """Launch the PyQt6 interface for a single image."""
+    """Launch the PyQt6 interface for multiple images."""
     app = QApplication.instance() or QApplication([])
-
-    img = image.convert("RGB")
-    data = img.tobytes("raw", "RGB")
-    qimg = QImage(data, img.width, img.height, QImage.Format.Format_RGB888)
-    pixmap = QPixmap.fromImage(qimg)
-
-    window = AnnotationWindow(pixmap, predictions, label_lines, label_file, class_names)
+    window = AnnotationWindow(images, predictions, labels, label_files, class_names)
     window.show()
     app.exec()
+


### PR DESCRIPTION
## Summary
- Switch to single-window PyQt interface with Previous/Next navigation and exit button
- Add brightness and contrast sliders for image display control
- Save button now writes updated labels for all images

## Testing
- `python -m py_compile annotation_corrector.py qt_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_6898f43fc7348326bc5975ca5585dcc6