### PR TITLE
Cache predictions and add flag to reuse them

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ The application provides a single PyQt6 interface that lets you work through all
 python annotation_corrector.py --images path/to/images --labels path/to/original_labels --corrected path/to/corrected_labels --model path/to/weights.pt
 ```
 
+Predictions are cached in a `predicted_labels` subdirectory inside the corrected labels folder. On subsequent runs you can skip
+recomputing predictions by adding the `--predictions` flag:
+
+```
+python annotation_corrector.py --images path/to/images --labels path/to/original_labels --corrected path/to/corrected_labels --model path/to/weights.pt --predictions
+```
+
 The script copies all label files from the `--labels` directory into the `--corrected` directory. Any accepted or edited labels are written to the corrected directory, leaving the originals untouched. Within the GUI you may:
 
 * Toggle prediction boxes on or off.


### PR DESCRIPTION
## Summary
- Add `--predictions` flag to load cached labels from a new `predicted_labels` folder.
- Save model outputs with confidence scores to `predicted_labels` for reuse.
- Document prediction caching and flag usage in README.

## Testing
- `python -m py_compile annotation_corrector.py`


------
https://chatgpt.com/codex/tasks/task_e_6898f944a620832697177dd1e9c7b33a