### PR TITLE
Add progress bar and filter non-image files

### DIFF
--- a/annotation_corrector.py
+++ b/annotation_corrector.py
@@ -5,10 +5,22 @@ import shutil
 from typing import List
 
 from PIL import Image
+from tqdm import tqdm
 
 from inference import load_model, predict
 from preprocessing import preprocess
 from qt_interface import run_interface
+
+
+IMAGE_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".bmp",
+    ".tif",
+    ".tiff",
+    ".webp",
+}
 
 
 def load_labels(label_file: str) -> List[str]:
@@ -53,14 +65,18 @@ def main():
     if not args.predictions:
         model = load_model(args.model)
         class_names = getattr(getattr(model, "model", None), "names", [])
-    image_paths = sorted(glob.glob(os.path.join(args.images, '*')))
+    image_paths = sorted(
+        p
+        for p in glob.glob(os.path.join(args.images, '*'))
+        if os.path.splitext(p)[1].lower() in IMAGE_EXTENSIONS
+    )
 
     images = []
     predictions = []
     labels = []
     label_files = []
 
-    for img_path in image_paths:
+    for img_path in tqdm(image_paths, desc="Processing images"):
         image = Image.open(img_path).convert('RGB')
         processed = preprocess(image)
         base = os.path.splitext(os.path.basename(img_path))[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ultralytics
 pillow
 PyQt6
 sahi
+tqdm


### PR DESCRIPTION
## Summary
- Filter inference input to include only common image extensions and skip other files
- Add a progress bar to show inference progress across images
- Include `tqdm` dependency for progress bar support

## Testing
- `python -m py_compile annotation_corrector.py inference.py`

------
https://chatgpt.com/codex/tasks/task_e_6898fe2117708326841d59e8756c8d69