### PR TITLE
Refactor Qt interface into modular components

### DIFF
--- a/annotation_corrector.py
+++ b/annotation_corrector.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 from inference import load_model, predict
 from preprocessing import preprocess
-from qt_interface import run_interface
+from window import run_interface
 
 
 def load_labels(label_file: str) -> List[str]:

--- a/graphics_items.py
+++ b/graphics_items.py
@@ -1,0 +1,251 @@
+"""Interactive graphics items representing bounding boxes.
+
+This module provides two :class:`PyQt6.QtWidgets.QGraphicsRectItem` subclasses
+used within the annotation tool:
+
+``PredBox``
+    Represents a predicted bounding box.  Clicking the box toggles whether the
+    prediction should be accepted and saved.  Small handles in the top-left and
+    bottom-right corners allow resizing.
+
+``GTBox``
+    Represents an existing ground-truth bounding box.  Clicking toggles whether
+    the annotation is kept.  It shares the same resize behaviour as ``PredBox``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, TYPE_CHECKING
+
+from PyQt6.QtCore import QRectF
+from PyQt6.QtGui import QColor, QPen
+from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsTextItem
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type hints
+    from window import AnnotationWindow
+
+
+def rect_to_yolo_line(rect: QRectF, cls_id: int, img_w: int, img_h: int) -> str:
+    """Convert a ``QRectF`` to a YOLO-format label line."""
+
+    xc = (rect.left() + rect.width() / 2) / img_w
+    yc = (rect.top() + rect.height() / 2) / img_h
+    w = rect.width() / img_w
+    h = rect.height() / img_h
+    return f"{cls_id} {xc:.6f} {yc:.6f} {w:.6f} {h:.6f}"
+
+
+class PredBox(QGraphicsRectItem):
+    """Graphics item for a predicted box."""
+
+    HANDLE_SIZE = 10
+
+    def __init__(
+        self,
+        rect: QRectF,
+        state: dict,
+        class_names: List[str],
+        window: "AnnotationWindow",
+        img_w: int,
+        img_h: int,
+    ) -> None:
+        super().__init__(rect)
+        self.window = window
+        self.state = state
+        self.line = state["line"]
+        self.conf = state["conf"]
+        self.accepted = state.get("accepted", False)
+        self.setPen(QPen(QColor("red"), 2))
+        self.img_w = img_w
+        self.img_h = img_h
+        self._resizing: Optional[str] = None
+
+        cls_id = int(self.line.split()[0])
+        cls_name = class_names[cls_id] if 0 <= cls_id < len(class_names) else str(cls_id)
+        self.label = QGraphicsTextItem(self)
+        self.label.setHtml(
+            f"<div style='background-color:white;'>{cls_name}:{self.conf:.2f}</div>"
+        )
+        self.label.setPos(rect.left(), rect.top() - 20)
+
+        self.tick = QGraphicsTextItem(self)
+        self._update_tick()
+        self.tick.setPos(rect.right() + 2, rect.top() - 20)
+
+    def _update_tick(self) -> None:
+        """Display a checkmark indicating whether the prediction is accepted."""
+
+        color = "green" if self.accepted else "gray"
+        self.tick.setHtml(f"<div style='color:{color};background-color:white;'>✓</div>")
+
+    # ------------------------------------------------------------------
+    # Resizing helpers
+    # ------------------------------------------------------------------
+    def _start_resize(self, event) -> bool:
+        r = self.rect()
+        pos = event.pos()
+        if abs(pos.x() - r.left()) <= self.HANDLE_SIZE and abs(pos.y() - r.top()) <= self.HANDLE_SIZE:
+            self._resizing = "topleft"
+        elif abs(pos.x() - r.right()) <= self.HANDLE_SIZE and abs(pos.y() - r.bottom()) <= self.HANDLE_SIZE:
+            self._resizing = "bottomright"
+        else:
+            self._resizing = None
+        return self._resizing is not None
+
+    def _resize(self, event) -> None:
+        if not self._resizing:
+            return
+        r = self.rect()
+        pos = event.pos()
+        if self._resizing == "topleft":
+            r.setTopLeft(pos)
+        elif self._resizing == "bottomright":
+            r.setBottomRight(pos)
+        self.setRect(r)
+        self._update_from_rect()
+
+    def _update_from_rect(self) -> None:
+        cls_id = int(self.line.split()[0])
+        self.line = rect_to_yolo_line(self.rect(), cls_id, self.img_w, self.img_h)
+        self.state["line"] = self.line
+        self.label.setPos(self.rect().left(), self.rect().top() - 20)
+        self.tick.setPos(self.rect().right() + 2, self.rect().top() - 20)
+        if self.window.final_checkbox.isChecked():
+            self.window.update_final_items()
+        self.window.flag_predictions()
+
+    # ------------------------------------------------------------------
+    # Mouse events
+    # ------------------------------------------------------------------
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        """Toggle acceptance or start resizing on mouse press."""
+
+        if self._start_resize(event):
+            QGraphicsRectItem.mousePressEvent(self, event)
+            return
+        # Toggle accepted state when clicked.
+        self.accepted = not self.accepted
+        self.state["accepted"] = self.accepted
+        self._update_tick()
+        super().mousePressEvent(event)
+        if self.window.final_checkbox.isChecked():
+            self.window.update_final_items()
+
+    def mouseMoveEvent(self, event) -> None:  # type: ignore[override]
+        if self._resizing:
+            self._resize(event)
+        else:
+            super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        if self._resizing:
+            self._resize(event)
+        self._resizing = None
+        super().mouseReleaseEvent(event)
+
+
+class GTBox(QGraphicsRectItem):
+    """Graphics item for an existing ground truth box."""
+
+    HANDLE_SIZE = 10
+
+    def __init__(
+        self,
+        rect: QRectF,
+        state: dict,
+        class_names: List[str],
+        window: "AnnotationWindow",
+        img_w: int,
+        img_h: int,
+    ) -> None:
+        super().__init__(rect)
+        self.window = window
+        self.state = state
+        self.line = state["line"]
+        self.kept = state.get("kept", True)
+        self.setPen(QPen(QColor("green"), 2))
+        self.img_w = img_w
+        self.img_h = img_h
+        self._resizing: Optional[str] = None
+
+        cls_id = int(self.line.split()[0])
+        cls_name = class_names[cls_id] if 0 <= cls_id < len(class_names) else str(cls_id)
+        self.label = QGraphicsTextItem(self)
+        self.label.setHtml(f"<div style='background-color:white;'>{cls_name}</div>")
+        self.label.setPos(rect.left(), rect.top() - 20)
+
+        self.cross = QGraphicsTextItem(self)
+        self._update_cross()
+        self.cross.setPos(rect.right() + 2, rect.top() - 20)
+
+    def _update_cross(self) -> None:
+        """Display a cross indicating whether the annotation is kept."""
+
+        color = "red" if self.kept else "gray"
+        self.cross.setHtml(f"<div style='color:{color};background-color:white;'>✗</div>")
+
+    # ------------------------------------------------------------------
+    # Resizing helpers
+    # ------------------------------------------------------------------
+    def _start_resize(self, event) -> bool:
+        r = self.rect()
+        pos = event.pos()
+        if abs(pos.x() - r.left()) <= self.HANDLE_SIZE and abs(pos.y() - r.top()) <= self.HANDLE_SIZE:
+            self._resizing = "topleft"
+        elif abs(pos.x() - r.right()) <= self.HANDLE_SIZE and abs(pos.y() - r.bottom()) <= self.HANDLE_SIZE:
+            self._resizing = "bottomright"
+        else:
+            self._resizing = None
+        return self._resizing is not None
+
+    def _resize(self, event) -> None:
+        if not self._resizing:
+            return
+        r = self.rect()
+        pos = event.pos()
+        if self._resizing == "topleft":
+            r.setTopLeft(pos)
+        elif self._resizing == "bottomright":
+            r.setBottomRight(pos)
+        self.setRect(r)
+        self._update_from_rect()
+
+    def _update_from_rect(self) -> None:
+        cls_id = int(self.line.split()[0])
+        self.line = rect_to_yolo_line(self.rect(), cls_id, self.img_w, self.img_h)
+        self.state["line"] = self.line
+        self.label.setPos(self.rect().left(), self.rect().top() - 20)
+        self.cross.setPos(self.rect().right() + 2, self.rect().top() - 20)
+        if self.window.final_checkbox.isChecked():
+            self.window.update_final_items()
+        self.window.flag_predictions()
+
+    # ------------------------------------------------------------------
+    # Mouse events
+    # ------------------------------------------------------------------
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        """Toggle whether the ground truth annotation is kept."""
+
+        if self._start_resize(event):
+            QGraphicsRectItem.mousePressEvent(self, event)
+            return
+        self.kept = not self.kept
+        self.state["kept"] = self.kept
+        self._update_cross()
+        super().mousePressEvent(event)
+        if self.window.final_checkbox.isChecked():
+            self.window.update_final_items()
+        self.window.flag_predictions()
+
+    def mouseMoveEvent(self, event) -> None:  # type: ignore[override]
+        if self._resizing:
+            self._resize(event)
+        else:
+            super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        if self._resizing:
+            self._resize(event)
+        self._resizing = None
+        super().mouseReleaseEvent(event)
+

--- a/tests/test_graphics_items.py
+++ b/tests/test_graphics_items.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.append(os.getcwd())
+
+from PyQt6.QtCore import QRectF
+from PyQt6.QtWidgets import QApplication, QCheckBox, QGraphicsScene
+from PyQt6.QtTest import QTest
+
+from graphics_items import GTBox, PredBox
+from view_utils import ZoomableGraphicsView
+
+
+class DummyWindow:
+    """Minimal stub implementing callbacks expected by the items."""
+
+    def __init__(self):
+        self.final_checkbox = QCheckBox()
+
+    def update_final_items(self):
+        pass
+
+    def flag_predictions(self):
+        pass
+
+
+def test_predbox_state_update():
+    app = QApplication.instance() or QApplication([])
+    scene = QGraphicsScene()
+    view = ZoomableGraphicsView(scene)
+    win = DummyWindow()
+    rect = QRectF(0, 0, 20, 20)
+    state = {"line": "0 0.1 0.1 0.2 0.2", "conf": 0.9, "accepted": False}
+    box = PredBox(rect, state, ["obj"], win, 100, 100)
+    scene.addItem(box)
+    view.show()
+    QTest.qWait(10)  # exercise event loop
+    box.accepted = True
+    box._update_tick()
+    assert box.accepted is True
+
+
+def test_gtbox_state_update():
+    app = QApplication.instance() or QApplication([])
+    scene = QGraphicsScene()
+    view = ZoomableGraphicsView(scene)
+    win = DummyWindow()
+    rect = QRectF(0, 0, 20, 20)
+    state = {"line": "0 0.1 0.1 0.2 0.2", "kept": True}
+    box = GTBox(rect, state, ["obj"], win, 100, 100)
+    scene.addItem(box)
+    view.show()
+    QTest.qWait(10)
+    box.kept = False
+    box._update_cross()
+    assert box.kept is False
+

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.append(os.getcwd())
+
+from PyQt6.QtCore import QPoint, QPointF, Qt
+from PyQt6.QtGui import QWheelEvent
+from PyQt6.QtWidgets import QApplication, QGraphicsScene
+
+from view_utils import ZoomableGraphicsView
+
+
+def test_zoomable_graphics_view_zoom():
+    """Wheel events should scale the view's transformation matrix."""
+
+    app = QApplication.instance() or QApplication([])
+    scene = QGraphicsScene()
+    view = ZoomableGraphicsView(scene)
+    view.show()  # required so the viewport exists
+    initial = view.transform().m11()
+
+    event = QWheelEvent(
+        QPointF(),
+        QPointF(),
+        QPoint(),
+        QPoint(0, 120),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.ScrollUpdate,
+        False,
+    )
+    view.wheelEvent(event)
+
+    assert view.transform().m11() > initial
+

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.append(os.getcwd())
+
+from PIL import Image
+from PyQt6.QtWidgets import QApplication
+
+from window import AnnotationWindow
+
+
+def test_annotation_window_smoke(tmp_path):
+    """Smoke test ensuring the window can be constructed and basic methods run."""
+
+    app = QApplication.instance() or QApplication([])
+    img = Image.new("RGB", (10, 10))
+    images = [img]
+    preds = [[{"line": "0 0.5 0.5 0.2 0.2", "conf": 0.9, "accepted": False}]]
+    gts = [[{"line": "0 0.5 0.5 0.2 0.2", "kept": True}]]
+    label_files = [str(tmp_path / "labels.txt")]
+    window = AnnotationWindow(images, preds, gts, label_files, ["obj"])
+
+    # Trigger a few simple operations
+    window.flag_predictions()
+    window.update_final_items()
+    window.collect_lines(0)
+    window.save_all()
+

--- a/view_utils.py
+++ b/view_utils.py
@@ -1,0 +1,41 @@
+"""Utility classes for Qt graphics views.
+
+This module currently provides :class:`ZoomableGraphicsView`, a thin wrapper
+around :class:`PyQt6.QtWidgets.QGraphicsView` that adds convenient mouse-wheel
+zooming behaviour.  The view is used throughout the application to display the
+annotated images.
+"""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QWheelEvent
+from PyQt6.QtWidgets import QGraphicsView
+
+
+class ZoomableGraphicsView(QGraphicsView):
+    """Graphics view supporting zooming and panning.
+
+    The view enables scroll-hand dragging for panning and performs a simple
+    scaling transformation when the user rotates the mouse wheel.  The
+    transformation anchor is set so that zooming is centred on the cursor
+    position, which provides an intuitive user experience.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Allow the user to pan the scene by dragging with the mouse.
+        self.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
+        # Ensure zooming occurs relative to the cursor position.
+        self.setTransformationAnchor(
+            QGraphicsView.ViewportAnchor.AnchorUnderMouse
+        )
+
+    def wheelEvent(self, event: QWheelEvent) -> None:  # type: ignore[override]
+        """Scale the view matrix in response to a wheel event."""
+
+        # Positive delta values indicate that the wheel was rotated away from
+        # the user (zoom in); negative values mean zoom out.
+        factor = 1.25 if event.angleDelta().y() > 0 else 0.8
+        self.scale(factor, factor)
+


### PR DESCRIPTION
## Summary
- Split monolithic Qt interface into `view_utils`, `graphics_items`, and `window` modules
- Document graphics items, main window signals/slots, and zoomable view
- Add basic smoke tests for view, graphics items, and window components

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898fe2672d48326b113ab39fc0946fb