### PR TITLE
Improve annotation UI usability

### DIFF
--- a/annotation_corrector.py
+++ b/annotation_corrector.py
@@ -38,7 +38,11 @@ def load_labels(label_file: str) -> List[str]:
         List[str]: List of label lines.
     """
     if not os.path.exists(label_file):
-        logging.warning("Label file missing: %s", label_file)
+        # Simply return an empty list when the label file is missing.
+        # Previously a warning was logged here which interfered with the
+        # tqdm progress bar output.  Suppressing the warning keeps the
+        # progress bar intact while still handling the missing file
+        # gracefully.
         return []
     try:
         with open(label_file) as f:

--- a/graphics_items.py
+++ b/graphics_items.py
@@ -70,7 +70,9 @@ class PredBox(QGraphicsRectItem):
 
         self.tick = QGraphicsTextItem(self)
         self._update_tick()
-        self.tick.setPos(rect.right() + 2, rect.top() - 20)
+        # Place the tick at the bottom-left of the rectangle so it does not
+        # interfere with the resize handles located at the corners.
+        self.tick.setPos(rect.left(), rect.bottom() + 2)
 
     def _update_tick(self) -> None:
         """Display a checkmark indicating whether the prediction is accepted."""
@@ -109,7 +111,7 @@ class PredBox(QGraphicsRectItem):
         self.line = rect_to_yolo_line(self.rect(), cls_id, self.img_w, self.img_h)
         self.state["line"] = self.line
         self.label.setPos(self.rect().left(), self.rect().top() - 20)
-        self.tick.setPos(self.rect().right() + 2, self.rect().top() - 20)
+        self.tick.setPos(self.rect().left(), self.rect().bottom() + 2)
         if self.window.final_checkbox.isChecked():
             self.window.update_final_items()
         self.window.flag_predictions()
@@ -176,7 +178,9 @@ class GTBox(QGraphicsRectItem):
 
         self.cross = QGraphicsTextItem(self)
         self._update_cross()
-        self.cross.setPos(rect.right() + 2, rect.top() - 20)
+        # Position the cross at the bottom-left to mirror the tick placement
+        # for predicted boxes and free up space near the top-right corner.
+        self.cross.setPos(rect.left(), rect.bottom() + 2)
 
     def _update_cross(self) -> None:
         """Display a cross indicating whether the annotation is kept."""
@@ -215,7 +219,7 @@ class GTBox(QGraphicsRectItem):
         self.line = rect_to_yolo_line(self.rect(), cls_id, self.img_w, self.img_h)
         self.state["line"] = self.line
         self.label.setPos(self.rect().left(), self.rect().top() - 20)
-        self.cross.setPos(self.rect().right() + 2, self.rect().top() - 20)
+        self.cross.setPos(self.rect().left(), self.rect().bottom() + 2)
         if self.window.final_checkbox.isChecked():
             self.window.update_final_items()
         self.window.flag_predictions()

--- a/window.py
+++ b/window.py
@@ -78,6 +78,9 @@ class AnnotationWindow(QMainWindow):
         self.label_files = label_files
         self.index = 0
 
+        # Ensure the window can receive key events for navigation.
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
         self.scene = QGraphicsScene(self)
         self.view = ZoomableGraphicsView(self.scene)
 
@@ -250,6 +253,19 @@ class AnnotationWindow(QMainWindow):
 
         if self.index > 0:
             self.load_image(self.index - 1)
+
+    # ------------------------------------------------------------------
+    # Keyboard navigation
+    # ------------------------------------------------------------------
+    def keyPressEvent(self, event) -> None:  # type: ignore[override]
+        """Handle left/right arrow keys to navigate images."""
+
+        if event.key() == Qt.Key.Key_Right:
+            self.next_image()
+        elif event.key() == Qt.Key.Key_Left:
+            self.prev_image()
+        else:
+            super().keyPressEvent(event)
 
     def collect_lines(self, idx: int) -> List[str]:
         """Gather YOLO label lines for image ``idx``."""


### PR DESCRIPTION
## Summary
- Suppress missing label warnings to keep tqdm progress bar intact
- Navigate images with left/right arrow keys
- Move checkmark and cross markers to bottom-left of boxes for unobstructed resizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689905fe8a54832695906fc4f2f85a35