### PR TITLE
Load class names when using cached predictions

### DIFF
--- a/annotation_corrector.py
+++ b/annotation_corrector.py
@@ -77,11 +77,12 @@ def main():
     pred_dir = os.path.join(args.corrected, "predicted_labels")
     os.makedirs(pred_dir, exist_ok=True)
 
-    model = None
-    class_names: List[str] = []
-    if not args.predictions:
-        model = load_model(args.model)
-        class_names = getattr(getattr(model, "model", None), "names", [])
+    model = load_model(args.model)
+    class_names: List[str] = getattr(getattr(model, "model", None), "names", [])
+    if args.predictions:
+        # When using cached predictions we still need the class names but can
+        # discard the model to avoid unnecessary memory usage.
+        model = None
     image_paths = sorted(
         p
         for p in glob.glob(os.path.join(args.images, '*'))

--- a/tests/test_annotation_corrector.py
+++ b/tests/test_annotation_corrector.py
@@ -1,0 +1,63 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.append(os.getcwd())
+
+from PIL import Image
+
+import annotation_corrector
+
+
+def test_class_names_loaded_with_predictions(tmp_path, monkeypatch):
+    images_dir = tmp_path / "images"
+    labels_dir = tmp_path / "labels"
+    corrected_dir = tmp_path / "corrected"
+    images_dir.mkdir()
+    labels_dir.mkdir()
+    corrected_dir.mkdir()
+
+    # Create a dummy image
+    img_path = images_dir / "img0.jpg"
+    Image.new("RGB", (10, 10)).save(img_path)
+
+    # Original labels (empty to force mismatch with predictions)
+    (labels_dir / "img0.txt").write_text("")
+
+    # Cached predictions
+    pred_dir = corrected_dir / "predicted_labels"
+    pred_dir.mkdir()
+    (pred_dir / "img0.txt").write_text("0 0.5 0.5 0.2 0.2 0.9\n")
+
+    class DummyModel:
+        def __init__(self):
+            self.model = type("m", (), {"names": ["cls"]})()
+
+    def fake_load_model(path):
+        return DummyModel()
+
+    captured = {}
+
+    def fake_run_interface(images, predictions, labels, label_files, class_names):
+        captured["class_names"] = class_names
+
+    monkeypatch.setattr(annotation_corrector, "load_model", fake_load_model)
+    monkeypatch.setattr(annotation_corrector, "run_interface", fake_run_interface)
+
+    args = [
+        "prog",
+        "--images",
+        str(images_dir),
+        "--labels",
+        str(labels_dir),
+        "--corrected",
+        str(corrected_dir),
+        "--model",
+        "dummy.pt",
+        "--predictions",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    annotation_corrector.main()
+
+    assert captured["class_names"] == ["cls"]


### PR DESCRIPTION
## Summary
- Always load the YOLO model to obtain class names and discard it when using cached predictions
- Add regression test ensuring class names are retrieved from the model even when predictions are precomputed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899093960148326995a54c3b6dcd242