### PR TITLE
Fix interaction blocking and show class labels

### DIFF
--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -5,7 +5,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 sys.path.append(os.getcwd())
 
 from PIL import Image
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication, QGraphicsTextItem
 
 from window import AnnotationWindow
 
@@ -26,4 +26,22 @@ def test_annotation_window_smoke(tmp_path):
     window.update_final_items()
     window.collect_lines(0)
     window.save_all()
+
+
+def test_final_items_show_classes(tmp_path):
+    app = QApplication.instance() or QApplication([])
+    img = Image.new("RGB", (10, 10))
+    images = [img]
+    preds = [[{"line": "0 0.5 0.5 0.2 0.2", "conf": 0.9, "accepted": True}]]
+    gts = [[{"line": "0 0.5 0.5 0.2 0.2", "kept": True}]]
+    label_files = [str(tmp_path / "labels.txt")]
+    window = AnnotationWindow(images, preds, gts, label_files, ["obj"])
+    window.final_checkbox.setChecked(True)
+    window.update_final_items()
+    texts = [
+        item.toPlainText()
+        for item in window.final_items
+        if isinstance(item, QGraphicsTextItem)
+    ]
+    assert "obj" in texts
 

--- a/view_utils.py
+++ b/view_utils.py
@@ -8,7 +8,9 @@ annotated images.
 
 from __future__ import annotations
 
-from PyQt6.QtCore import Qt
+from typing import Optional
+
+from PyQt6.QtCore import QPoint, Qt
 from PyQt6.QtGui import QWheelEvent
 from PyQt6.QtWidgets import QGraphicsView
 
@@ -16,16 +18,18 @@ from PyQt6.QtWidgets import QGraphicsView
 class ZoomableGraphicsView(QGraphicsView):
     """Graphics view supporting zooming and panning.
 
-    The view enables scroll-hand dragging for panning and performs a simple
-    scaling transformation when the user rotates the mouse wheel.  The
-    transformation anchor is set so that zooming is centred on the cursor
+    The view performs a simple scaling transformation when the user rotates
+    the mouse wheel.  Panning is implemented manually using the middle mouse
+    button so that left-click interactions on scene items remain available.
+    The transformation anchor is set so that zooming is centred on the cursor
     position, which provides an intuitive user experience.
     """
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        # Allow the user to pan the scene by dragging with the mouse.
-        self.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
+        # Start with no drag mode so items can receive mouse events.
+        self.setDragMode(QGraphicsView.DragMode.NoDrag)
+        self._last_pan_point: Optional[QPoint] = None
         # Ensure zooming occurs relative to the cursor position.
         self.setTransformationAnchor(
             QGraphicsView.ViewportAnchor.AnchorUnderMouse
@@ -38,4 +42,31 @@ class ZoomableGraphicsView(QGraphicsView):
         # the user (zoom in); negative values mean zoom out.
         factor = 1.25 if event.angleDelta().y() > 0 else 0.8
         self.scale(factor, factor)
+
+    def mousePressEvent(self, event):  # type: ignore[override]
+        if event.button() == Qt.MouseButton.MiddleButton:
+            self._last_pan_point = event.pos()
+            self.setCursor(Qt.CursorShape.ClosedHandCursor)
+        else:
+            super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):  # type: ignore[override]
+        if self._last_pan_point is not None:
+            delta = event.pos() - self._last_pan_point
+            self._last_pan_point = event.pos()
+            self.horizontalScrollBar().setValue(
+                self.horizontalScrollBar().value() - delta.x()
+            )
+            self.verticalScrollBar().setValue(
+                self.verticalScrollBar().value() - delta.y()
+            )
+        else:
+            super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):  # type: ignore[override]
+        if event.button() == Qt.MouseButton.MiddleButton:
+            self._last_pan_point = None
+            self.setCursor(Qt.CursorShape.ArrowCursor)
+        else:
+            super().mouseReleaseEvent(event)
 

--- a/window.py
+++ b/window.py
@@ -11,9 +11,11 @@ from PyQt6.QtGui import QColor, QImage, QPixmap, QPen
 from PyQt6.QtWidgets import (
     QApplication,
     QCheckBox,
+    QGraphicsItem,
     QGraphicsPixmapItem,
     QGraphicsRectItem,
     QGraphicsScene,
+    QGraphicsTextItem,
     QHBoxLayout,
     QLabel,
     QMainWindow,
@@ -86,7 +88,7 @@ class AnnotationWindow(QMainWindow):
 
         self.pred_items: List[PredBox] = []
         self.gt_items: List[GTBox] = []
-        self.final_items: List[QGraphicsRectItem] = []
+        self.final_items: List[QGraphicsItem] = []
 
         # Checkboxes controlling visibility of annotation layers
         self.pred_checkbox = QCheckBox("Show predictions")
@@ -318,12 +320,38 @@ class AnnotationWindow(QMainWindow):
                 rect.setPen(QPen(QColor("blue"), 2))
                 self.scene.addItem(rect)
                 self.final_items.append(rect)
+                cls_id = int(item.line.split()[0])
+                cls_name = (
+                    self.class_names[cls_id]
+                    if 0 <= cls_id < len(self.class_names)
+                    else str(cls_id)
+                )
+                label = QGraphicsTextItem()
+                label.setHtml(
+                    f"<div style='color:blue;background-color:white;'>{cls_name}</div>"
+                )
+                label.setPos(item.rect().left(), item.rect().top() - 20)
+                self.scene.addItem(label)
+                self.final_items.append(label)
         for item in self.pred_items:
             if item.accepted:
                 rect = QGraphicsRectItem(item.rect())
                 rect.setPen(QPen(QColor("blue"), 2))
                 self.scene.addItem(rect)
                 self.final_items.append(rect)
+                cls_id = int(item.line.split()[0])
+                cls_name = (
+                    self.class_names[cls_id]
+                    if 0 <= cls_id < len(self.class_names)
+                    else str(cls_id)
+                )
+                label = QGraphicsTextItem()
+                label.setHtml(
+                    f"<div style='color:blue;background-color:white;'>{cls_name}</div>"
+                )
+                label.setPos(item.rect().left(), item.rect().top() - 20)
+                self.scene.addItem(label)
+                self.final_items.append(label)
 
     def preview(self) -> None:
         """Display a message box with the final labels for the current image."""


### PR DESCRIPTION
## Summary
- Enable middle-button panning so left-click can resize boxes or use cross/tick controls
- Display class names beside each box in the final labels overlay
- Test that final overlay includes class labels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990b0f4ca48326b644472cea4820bf