### PR TITLE
Improve annotation toggles and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Interactive tool for reviewing YOLO annotations. It runs an Ultralytics YOLO model on a set of images and compares the predictions with existing label files. Only images where the predictions and labels differ are presented to the user for review.
 
-The application provides a single PyQt6 interface that lets you work through all images without reopening the window. Model predictions (in red) can be toggled on and off, each showing its confidence and a check mark for accepting the prediction. Existing labels (in green) display a cross that can be clicked to remove them. A preview window shows the final label lines before saving.
+The application provides a single PyQt6 interface that lets you work through all images without reopening the window. Model predictions (in red) display a green tick to add them and a red cross to remove them once accepted. Existing labels (in green) show a red cross for removal and switch to a green tick to add them back. A preview window shows the final label lines before saving.
 
 ## Usage
 
@@ -20,8 +20,8 @@ python annotation_corrector.py --images path/to/images --labels path/to/original
 The script copies all label files from the `--labels` directory into the `--corrected` directory. Any accepted or edited labels are written to the corrected directory, leaving the originals untouched. Within the GUI you may:
 
 * Toggle prediction boxes on or off.
-* Click the **✓** on a prediction to include it.
-* Click the **✗** on a ground-truth box to remove it.
+* Click the **✓** on a prediction to include it, or **✗** to remove it.
+* Click the **✗** on a ground-truth box to remove it, or **✓** to add it back.
 * Adjust image display using brightness and contrast sliders.
 * Move between images with **Previous** and **Next**.
 * Press **Save** to write labels for all images and **Exit** to close the tool.

--- a/tests/test_graphics_items.py
+++ b/tests/test_graphics_items.py
@@ -37,8 +37,9 @@ def test_predbox_state_update():
     view.show()
     QTest.qWait(10)  # exercise event loop
     box.accepted = True
-    box._update_tick()
+    box._update_icon()
     assert box.accepted is True
+    assert "✗" in box.icon.toHtml()
 
 
 def test_gtbox_state_update():
@@ -53,6 +54,7 @@ def test_gtbox_state_update():
     view.show()
     QTest.qWait(10)
     box.kept = False
-    box._update_cross()
+    box._update_icon()
     assert box.kept is False
+    assert "✓" in box.icon.toHtml()
 

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -6,6 +6,7 @@ sys.path.append(os.getcwd())
 
 from PIL import Image
 from PyQt6.QtWidgets import QApplication, QGraphicsTextItem
+import pytest
 
 from window import AnnotationWindow
 
@@ -44,4 +45,27 @@ def test_final_items_show_classes(tmp_path):
         if isinstance(item, QGraphicsTextItem)
     ]
     assert "obj" in texts
+
+
+def test_navigation_preserves_view(tmp_path):
+    app = QApplication.instance() or QApplication([])
+    img = Image.new("RGB", (1000, 1000))
+    images = [img, img]
+    preds = [
+        [{"line": "0 0.5 0.5 0.2 0.2", "conf": 0.9, "accepted": False}],
+        [{"line": "0 0.5 0.5 0.2 0.2", "conf": 0.8, "accepted": False}],
+    ]
+    gts = [
+        [{"line": "0 0.5 0.5 0.2 0.2", "kept": True}],
+        [{"line": "0 0.5 0.5 0.2 0.2", "kept": True}],
+    ]
+    label_files = [str(tmp_path / "a.txt"), str(tmp_path / "b.txt")]
+    window = AnnotationWindow(images, preds, gts, label_files, ["obj"])
+    window.view.scale(2, 2)
+    window.view.horizontalScrollBar().setValue(10)
+    window.view.verticalScrollBar().setValue(20)
+    window.next_image()
+    assert window.view.transform().m11() == pytest.approx(2)
+    assert window.view.horizontalScrollBar().value() == 10
+    assert window.view.verticalScrollBar().value() == 20
 

--- a/view_utils.py
+++ b/view_utils.py
@@ -19,8 +19,8 @@ class ZoomableGraphicsView(QGraphicsView):
     """Graphics view supporting zooming and panning.
 
     The view performs a simple scaling transformation when the user rotates
-    the mouse wheel.  Panning is implemented manually using the middle mouse
-    button so that left-click interactions on scene items remain available.
+    the mouse wheel.  Panning is implemented using the right mouse button so
+    that left-click interactions on scene items remain available.
     The transformation anchor is set so that zooming is centred on the cursor
     position, which provides an intuitive user experience.
     """
@@ -34,6 +34,8 @@ class ZoomableGraphicsView(QGraphicsView):
         self.setTransformationAnchor(
             QGraphicsView.ViewportAnchor.AnchorUnderMouse
         )
+        # Disable the context menu so right-click can be used for panning.
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.PreventContextMenu)
 
     def wheelEvent(self, event: QWheelEvent) -> None:  # type: ignore[override]
         """Scale the view matrix in response to a wheel event."""
@@ -44,7 +46,7 @@ class ZoomableGraphicsView(QGraphicsView):
         self.scale(factor, factor)
 
     def mousePressEvent(self, event):  # type: ignore[override]
-        if event.button() == Qt.MouseButton.MiddleButton:
+        if event.button() == Qt.MouseButton.RightButton:
             self._last_pan_point = event.pos()
             self.setCursor(Qt.CursorShape.ClosedHandCursor)
         else:
@@ -64,7 +66,7 @@ class ZoomableGraphicsView(QGraphicsView):
             super().mouseMoveEvent(event)
 
     def mouseReleaseEvent(self, event):  # type: ignore[override]
-        if event.button() == Qt.MouseButton.MiddleButton:
+        if event.button() == Qt.MouseButton.RightButton:
             self._last_pan_point = None
             self.setCursor(Qt.CursorShape.ArrowCursor)
         else:

--- a/window.py
+++ b/window.py
@@ -184,6 +184,10 @@ class AnnotationWindow(QMainWindow):
 
     def load_image(self, index: int) -> None:
         """Load the image and associated boxes at ``index`` into the scene."""
+        # Preserve current scroll and zoom so navigation keeps the same view.
+        h_val = self.view.horizontalScrollBar().value()
+        v_val = self.view.verticalScrollBar().value()
+        transform = self.view.transform()
 
         self.scene.clear()
         self.pred_items = []
@@ -215,6 +219,11 @@ class AnnotationWindow(QMainWindow):
 
         self.flag_predictions()
         self.update_final_items()
+
+        # Restore previous view parameters
+        self.view.setTransform(transform)
+        self.view.horizontalScrollBar().setValue(h_val)
+        self.view.verticalScrollBar().setValue(v_val)
 
     def flag_predictions(self) -> None:
         """Highlight predictions that do not match any ground truth box."""


### PR DESCRIPTION
## Summary
- Switch prediction and ground-truth indicators between tick and cross to add/remove labels
- Allow right-click panning and preserve viewport when navigating images
- Test navigation keeps zoom and scroll positions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68991228e4948326beb23bdc7bba6de8