### PR TITLE
Use plus/minus icons for annotation toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Interactive tool for reviewing YOLO annotations. It runs an Ultralytics YOLO model on a set of images and compares the predictions with existing label files. Only images where the predictions and labels differ are presented to the user for review.
 
-The application provides a single PyQt6 interface that lets you work through all images without reopening the window. Model predictions (in red) display a green tick to add them and a red cross to remove them once accepted. Existing labels (in green) show a red cross for removal and switch to a green tick to add them back. A preview window shows the final label lines before saving.
+The application provides a single PyQt6 interface that lets you work through all images without reopening the window. Model predictions (in red) display a green "+" to add them and a red "-" to remove them once accepted. Existing labels (in green) show a red "-" for removal and switch to a green "+" to add them back. A preview window shows the final label lines before saving.
 
 ## Usage
 
@@ -20,8 +20,8 @@ python annotation_corrector.py --images path/to/images --labels path/to/original
 The script copies all label files from the `--labels` directory into the `--corrected` directory. Any accepted or edited labels are written to the corrected directory, leaving the originals untouched. Within the GUI you may:
 
 * Toggle prediction boxes on or off.
-* Click the **✓** on a prediction to include it, or **✗** to remove it.
-* Click the **✗** on a ground-truth box to remove it, or **✓** to add it back.
+* Click the **+** on a prediction to include it, or **-** to remove it.
+* Click the **-** on a ground-truth box to remove it, or **+** to add it back.
 * Adjust image display using brightness and contrast sliders.
 * Move between images with **Previous** and **Next**.
 * Press **Save** to write labels for all images and **Exit** to close the tool.

--- a/graphics_items.py
+++ b/graphics_items.py
@@ -76,13 +76,13 @@ class PredBox(QGraphicsRectItem):
         self.icon.setPos(rect.left(), rect.bottom() + 2)
 
     def _update_icon(self) -> None:
-        """Display a tick to add or a cross to remove a prediction."""
+        """Display a '+' to add or a '-' to remove a prediction."""
 
         if self.accepted:
-            symbol = "✗"
+            symbol = "-"
             color = "red"
         else:
-            symbol = "✓"
+            symbol = "+"
             color = "green"
         self.icon.setHtml(
             f"<div style='color:{color};background-color:white;'>{symbol}</div>"
@@ -195,13 +195,13 @@ class GTBox(QGraphicsRectItem):
         self.icon.setPos(rect.left(), rect.bottom() + 2)
 
     def _update_icon(self) -> None:
-        """Display a cross to remove or a tick to add the annotation."""
+        """Display a '-' to remove or a '+' to add the annotation."""
 
         if self.kept:
-            symbol = "✗"
+            symbol = "-"
             color = "red"
         else:
-            symbol = "✓"
+            symbol = "+"
             color = "green"
         self.icon.setHtml(
             f"<div style='color:{color};background-color:white;'>{symbol}</div>"

--- a/tests/test_graphics_items.py
+++ b/tests/test_graphics_items.py
@@ -25,7 +25,7 @@ class DummyWindow:
         pass
 
 
-def test_predbox_state_update():
+def test_predbox_icon_symbols():
     app = QApplication.instance() or QApplication([])
     scene = QGraphicsScene()
     view = ZoomableGraphicsView(scene)
@@ -36,13 +36,13 @@ def test_predbox_state_update():
     scene.addItem(box)
     view.show()
     QTest.qWait(10)  # exercise event loop
+    assert "+" in box.icon.toHtml()
     box.accepted = True
     box._update_icon()
-    assert box.accepted is True
-    assert "✗" in box.icon.toHtml()
+    assert "-" in box.icon.toHtml()
 
 
-def test_gtbox_state_update():
+def test_gtbox_icon_symbols():
     app = QApplication.instance() or QApplication([])
     scene = QGraphicsScene()
     view = ZoomableGraphicsView(scene)
@@ -53,8 +53,8 @@ def test_gtbox_state_update():
     scene.addItem(box)
     view.show()
     QTest.qWait(10)
+    assert "-" in box.icon.toHtml()
     box.kept = False
     box._update_icon()
-    assert box.kept is False
-    assert "✓" in box.icon.toHtml()
+    assert "+" in box.icon.toHtml()
 


### PR DESCRIPTION
## Summary
- Replace tick/cross indicators with plus/minus symbols
- Document new icon semantics
- Test both ground truth and prediction icon toggling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689915ea06488326bfd7c338787bc101